### PR TITLE
feat: 🎸 Ruby 3.4.0 で除外される mutex_m gem を Gemfile に追加した

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source 'https://rubygems.org'
 
 gem 'fastlane'
 gem 'debug'
+gem 'mutex_m'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,6 +165,7 @@ GEM
     mini_mime (1.1.5)
     multi_json (1.15.0)
     multipart-post (2.4.0)
+    mutex_m (0.2.0)
     nanaimo (0.3.0)
     naturally (2.2.1)
     nkf (0.2.0)
@@ -227,6 +228,7 @@ PLATFORMS
 DEPENDENCIES
   debug
   fastlane
+  mutex_m
 
 BUNDLED WITH
    2.5.7


### PR DESCRIPTION
> fastlanewbie/vendor/bundle/ruby/3.3.0/gems/httpclient-2.8.3/lib/httpclient/auth.rb:11: warning: mutex_m was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add mutex_m to your Gemfile or gemspec. Also contact author of httpclient-2.8.3 to add mutex_m into its gemspec.
