### PR TITLE
feat: 🎸 Ruby 3.4.0 で除外される abbrev gem を Gemfile に追加した

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
+gem 'abbrev'
 gem 'fastlane'
 gem 'debug'
 gem 'mutex_m'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,7 @@ GEM
       base64
       nkf
       rexml
+    abbrev (0.1.2)
     addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
     artifactory (3.0.17)
@@ -226,6 +227,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  abbrev
   debug
   fastlane
   mutex_m


### PR DESCRIPTION
> fastlanewbie/vendor/bundle/ruby/3.3.0/gems/highline-2.0.3/lib/highline.rb:17: warning: abbrev was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add abbrev to your Gemfile or gemspec. Also contact author of highline-2.0.3 to add abbrev into its gemspec.